### PR TITLE
Add some padding to the body

### DIFF
--- a/index.hbs
+++ b/index.hbs
@@ -47,6 +47,7 @@ limitations under the License.
     body {
       max-width: 1280px;
       margin: 0 auto;
+      padding: 8px;
     }
     .title, .intro{
       text-align: center;


### PR DESCRIPTION
I was reading the page on my tablet, and since the screen size was smaller than your max-size of 1280px and you remove all padding and margin from `html` and `body`, the text was very hard to read with no space at all between the black borders of the screen and the black pixels of the characters. I understood that you're messing with the margins to get the document to be centered, so I just added some padding.

Technically, because of your box sizing, I think this reduces the max-width of the content to 1280px minus the padding, so changing the max-width to 1296px would preserve the current look on larger displays. I decided not to mess with it, but you decide.